### PR TITLE
Simples fixes for header errors and support of MSVC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+output.ppm

--- a/include/sjpg_bit_stream.h
+++ b/include/sjpg_bit_stream.h
@@ -2,9 +2,10 @@
 // Created by user on 2/18/24.
 //
 
-#ifndef SIMPLE_JPEG_CODEC_SJPG_BIT_STREAM_H
-#define SIMPLE_JPEG_CODEC_SJPG_BIT_STREAM_H
+# pragma once
+
 #include <string>
+#include <stdexcept>
 namespace sjpg_codec {
 class BitStream {
 public:
@@ -30,5 +31,3 @@ private:
   size_t pos_{0};
 };
 } // namespace sjpg_codec
-
-#endif // SIMPLE_JPEG_CODEC_SJPG_BIT_STREAM_H

--- a/include/sjpg_decoder.h
+++ b/include/sjpg_decoder.h
@@ -8,7 +8,15 @@
 #include "sjpg_huffman_table.h"
 #include "sjpg_segments.h"
 #include <fstream>
+
+#define _USE_MATH_DEFINES
 #include <cmath>
+
+// MSVC have additional header for constants
+#if defined _MSC_VER && !defined M_PI
+# include <corecrt_math_defines.h>
+#endif
+
 
 namespace sjpg_codec {
 using namespace segments;

--- a/include/sjpg_decoder.h
+++ b/include/sjpg_decoder.h
@@ -2,12 +2,13 @@
 // Created by user on 2/18/24.
 //
 
-#ifndef SIMPLE_JPEG_CODEC_SJPG_DECODER_H
-#define SIMPLE_JPEG_CODEC_SJPG_DECODER_H
+# pragma once
+
 #include "sjpg_bit_stream.h"
 #include "sjpg_huffman_table.h"
 #include "sjpg_segments.h"
 #include <fstream>
+#include <cmath>
 
 namespace sjpg_codec {
 using namespace segments;
@@ -480,4 +481,3 @@ private:
 };
 } // namespace sjpg_codec
 
-#endif // SIMPLE_JPEG_CODEC_SJPG_DECODER_H

--- a/include/sjpg_huffman_table.h
+++ b/include/sjpg_huffman_table.h
@@ -1,14 +1,15 @@
 //
 // Created by user on 2/18/24.
 //
-
-#ifndef SIMPLE_JPEG_CODEC_SJPG_HUFFMAN_TABLE_H
-#define SIMPLE_JPEG_CODEC_SJPG_HUFFMAN_TABLE_H
+# pragma once
 #include "sjpg_log.h"
 #include <bitset>
 #include <map>
 #include <numeric>
 #include <vector>
+#include <cstdint>
+#include <cassert>
+
 namespace sjpg_codec {
 class HuffmanTable {
 public:
@@ -92,4 +93,3 @@ private:
 };
 } // namespace sjpg_codec
 
-#endif // SIMPLE_JPEG_CODEC_SJPG_HUFFMAN_TABLE_H

--- a/include/sjpg_log.h
+++ b/include/sjpg_log.h
@@ -2,12 +2,10 @@
 // Created by user on 2/7/24.
 //
 
-#ifndef SIMPLE_JPEG_CODEC_SJPG_LOG_H
-#define SIMPLE_JPEG_CODEC_SJPG_LOG_H
+# pragma once
 
 #define LOG_INFO(...) printf(__VA_ARGS__)
 #define LOG_ERROR(...) printf(__VA_ARGS__)
 #define LOG_DEBUG(...) printf(__VA_ARGS__)
 #define LOG_WARN(...) printf(__VA_ARGS__)
 
-#endif // SIMPLE_JPEG_CODEC_SJPG_LOG_H

--- a/include/sjpg_segments.h
+++ b/include/sjpg_segments.h
@@ -1,9 +1,8 @@
 //
 // Created by user on 2/7/24.
 //
+# pragma once 
 
-#ifndef SIMPLE_JPEG_CODEC_SJPG_SEGMENTS_H
-#define SIMPLE_JPEG_CODEC_SJPG_SEGMENTS_H
 #include "sjpg_log.h"
 #include <vector>
 namespace sjpg_codec::segments {
@@ -182,4 +181,3 @@ public:
 };
 } // namespace sjpg_codec::segments
 
-#endif // SIMPLE_JPEG_CODEC_SJPG_SEGMENTS_H

--- a/tests/test_jpeg_decoder.cpp
+++ b/tests/test_jpeg_decoder.cpp
@@ -9,7 +9,7 @@ using namespace testing;
 class AJPEGDecoder : public Test {
 public:
   std::string filepath =
-      "/Users/user/Documents/develop/simple_jpeg_codec/resources/lenna.jpg";
+      "./resources/lenna.jpg";
   sjpg_codec::Decoder decoder;
 };
 


### PR DESCRIPTION
Thanks for project suitable for learning basics of baseline JPEG.

Few fixes:

- Removed absolute path for lena
- Removed absolute header definitions. Moved to `#pragma once`
- Add `cmath`, `stdexcept` and `cassert` headers